### PR TITLE
Remove installation of X11 dependencies from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,6 @@ jobs:
       - name: Tidy modules
         run: make tidy
 
-      - name: Install X11 dependencies
-        run: sudo apt update && sudo apt install -y libx11-dev xorg-dev
-
       - name: Run tests and generate coverage
         run: make coverage
 


### PR DESCRIPTION
### TL;DR
Removed X11 dependencies installation step from CI workflow

### What changed?
Removed the step that installs `libx11-dev` and `xorg-dev` packages via apt in the CI workflow

### How to test?
1. Verify that CI workflow runs successfully without X11 dependencies
2. Ensure all tests pass in the pipeline
3. Confirm coverage reports are still generated correctly

### Why make this change?
The X11 dependencies were likely unnecessary for the test suite execution and coverage generation, removing them simplifies the CI process and reduces build time