### PR TITLE
Add versioning support and release workflows; update CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set up Git
+        run: |
+          git config --global user.name "gcat CI"
+          git config --global user.email "ci@timsexperiments.foo"
+
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
@@ -63,7 +68,6 @@ jobs:
           fi
 
   build:
-    needs: [lint, test]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*" # trigger only when a semantic version tag is pushed
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.23.6"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,112 @@
+name: Version Bump
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled, closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: "Select the release type"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+      prerelease:
+        description: "Select a pre-release label if needed"
+        required: false
+        type: choice
+        options:
+          - alpha
+          - beta
+
+jobs:
+  calculate-version:
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.calc.outputs.new_version }}
+      release_type: ${{ steps.determine.outputs.release_type }}
+      prerelease: ${{ steps.determine.outputs.prerelease }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Determine Release Parameters
+        id: determine
+        run: |
+          RELEASE_TYPE=""
+          PRERELEASE=""
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              RELEASE_TYPE="${{ github.event.inputs.release_type }}"
+              PRERELEASE="${{ github.event.inputs.prerelease }}"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+              echo "Examining PR labels..."
+              for label in $(echo '${{ toJson(github.event.pull_request.labels) }}' | jq -r '.[].name'); do
+                  lower_label=$(echo "$label" | tr '[:upper:]' '[:lower:]')
+                  case "$lower_label" in
+                      major|minor|patch)
+                          RELEASE_TYPE="$lower_label"
+                          ;;
+                      alpha|beta)
+                          PRERELEASE="$lower_label"
+                          ;;
+                  esac
+              done
+          else
+              echo "Unsupported event type: ${{ github.event_name }}"
+              exit 1
+          fi
+
+          echo "Determined release_type: $RELEASE_TYPE"
+          echo "Determined prerelease: $PRERELEASE"
+          echo "release_type=${RELEASE_TYPE}" >> $GITHUB_OUTPUT
+          echo "prerelease=${PRERELEASE}" >> $GITHUB_OUTPUT
+
+      - name: Calculate New Version
+        id: calc
+        run: |
+          OLD_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          NEW_VERSION=$(./scripts/bump_version.sh "${{ steps.determine.outputs.release_type }}" "${{ steps.determine.outputs.prerelease }}")
+          if [ -n "$OLD_VERSION" ]; then
+            echo "bumping from $OLD_VERSION to $NEW_VERSION" >&2
+          else
+            echo "setting version to $NEW_VERSION" >&2
+          fi
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Warn if no version bump detected
+        if: ${{ github.event_name == 'pull_request' && steps.determine.outputs.release_type == '' }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: "⚠️ **Warning:** No version bump label was detected on this PR. If you intended to trigger a release, please add one of the following labels: `major`, `minor`, or `patch`."
+            })
+
+  bump-version:
+    needs: calculate-version
+    runs-on: ubuntu-latest
+    if: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.state == 'closed')) && needs.calculate-version.outputs.release_type != '' }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Set up Git
+        run: |
+          git config user.name "gcat CI"
+          git config user.email "ci@timsexperiments.foo"
+
+      - name: Create Version Tag
+        env:
+          NEW_VERSION: ${{ needs.calculate-version.outputs.new_version }}
+        run: |
+          echo "Tagging new version: $NEW_VERSION"
+          git tag "$NEW_VERSION"
+          git push origin "$NEW_VERSION"

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ go.work.sum
 
 # Build output
 /build/
+/dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,27 @@
+project_name: gcat
+
+builds:
+  - binary: gcat
+    main: ./cmd/gcat/main.go
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+    ldflags: "-s -w -X main.version={{ .Version }}"
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - README.md
+      - LICENSE.md
+
+changelog:
+  sort: asc
+
+release:
+  github:
+    owner: timsexperiments
+    name: gcat

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 BINARY_PATH := build/gcat/gcat
 GO ?= go
-BUILD_FLAGS := -ldflags="-s -w"
+# VERSION can be set via an environment variable (default is v0.0.0-dev)
+VERSION ?= v0.0.0-dev
+BUILD_FLAGS := -ldflags="-s -w -X main.version=$(VERSION)"
 COVERAGE_DIR := coverage
 COVERAGE_FILE := $(COVERAGE_DIR)/coverage.out
 

--- a/cmd/gcat/main.go
+++ b/cmd/gcat/main.go
@@ -10,6 +10,10 @@ import (
 	"github.com/timsexperiments/gcat/pkg/gcat"
 )
 
+// version is set at build time via linker flags.
+// It should follow semantic versioning with a "v" prefix (e.g., v1.2.3)
+var version = "v0.0.0-dev"
+
 var copyOutput bool
 
 func main() {
@@ -19,6 +23,14 @@ func main() {
 		Args:  cobra.ExactArgs(1),
 		Run:   runGcat,
 	}
+
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "version",
+		Short: "Print the version number of gcat",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("gcat version: %s\n", version)
+		},
+	})
 
 	rootCmd.Flags().BoolVarP(&copyOutput, "copy", "c", false, "Copy output to clipboard instead of printing")
 

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   ./scripts/calc_new_version.sh <major|minor|patch> [alpha|beta]
+# Example:
+#   ./scripts/calc_new_version.sh patch alpha
+#
+# The script reads the latest tag from the repository (defaulting to v0.0.0 if none exists),
+# calculates the new version based on semver rules with our prerelease transition logic,
+# and prints only the new version string.
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $0 <major|minor|patch> [alpha|beta]" >&2
+  exit 1
+fi
+
+RELEASE_TYPE=$1
+PRERELEASE=${2:-""}
+
+if [[ "$RELEASE_TYPE" != "major" && "$RELEASE_TYPE" != "minor" && "$RELEASE_TYPE" != "patch" ]]; then
+  echo "Error: release type must be one of: major, minor, patch" >&2
+  exit 1
+fi
+
+if [ -n "$PRERELEASE" ]; then
+  if [[ "$PRERELEASE" != "alpha" && "$PRERELEASE" != "beta" ]]; then
+    echo "Error: prerelease, if provided, must be alpha or beta" >&2
+    exit 1
+  fi
+fi
+
+LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+
+VERSION_NO_V=${LATEST_TAG#v}
+if [[ $VERSION_NO_V =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-([a-z]+)\.([0-9]+))?$ ]]; then
+  CURRENT_MAJOR=${BASH_REMATCH[1]}
+  CURRENT_MINOR=${BASH_REMATCH[2]}
+  CURRENT_PATCH=${BASH_REMATCH[3]}
+  CURRENT_PRERELEASE_TYPE=${BASH_REMATCH[5]:-}
+  CURRENT_PRERELEASE_NUM=${BASH_REMATCH[6]:-0}
+else
+  echo "Error: Latest tag '$LATEST_TAG' is not in a valid semantic version format." >&2
+  exit 1
+fi
+
+NEW_MAJOR=$CURRENT_MAJOR
+NEW_MINOR=$CURRENT_MINOR
+NEW_PATCH=$CURRENT_PATCH
+NEW_PRERELEASE=""
+
+case "$RELEASE_TYPE" in
+  major)
+    NEW_MAJOR=$((CURRENT_MAJOR + 1))
+    NEW_MINOR=0
+    NEW_PATCH=0
+    ;;
+  minor)
+    NEW_MINOR=$((CURRENT_MINOR + 1))
+    NEW_PATCH=0
+    ;;
+  patch)
+    if [ -n "$PRERELEASE" ]; then
+      # For patch bump with prerelease:
+      if [ -z "$CURRENT_PRERELEASE_TYPE" ]; then
+        # If no prerelease exists yet, bump the patch.
+        NEW_PATCH=$((CURRENT_PATCH + 1))
+      else
+        if [ "$CURRENT_PRERELEASE_TYPE" == "$PRERELEASE" ]; then
+          # Same prerelease type: do not change numeric version.
+          NEW_PATCH=$CURRENT_PATCH
+        elif [ "$CURRENT_PRERELEASE_TYPE" == "alpha" ] && [ "$PRERELEASE" == "beta" ]; then
+          # Allow switching from alpha to beta without bumping numeric part.
+          NEW_PATCH=$CURRENT_PATCH
+        elif [ "$CURRENT_PRERELEASE_TYPE" == "beta" ] && [ "$PRERELEASE" == "alpha" ]; then
+          echo "Error: Switching from beta to alpha in a patch bump is not allowed without a numeric bump." >&2
+          exit 1
+        else
+          # Fallback: bump numeric part.
+          NEW_PATCH=$((CURRENT_PATCH + 1))
+        fi
+      fi
+    else
+      NEW_PATCH=$((CURRENT_PATCH + 1))
+    fi
+    ;;
+esac
+
+# Set prerelease part if a prerelease argument is provided.
+if [ -n "$PRERELEASE" ]; then
+  if [ -z "$CURRENT_PRERELEASE_TYPE" ]; then
+    NEW_PRERELEASE="${PRERELEASE}.1"
+  else
+    if [ "$CURRENT_PRERELEASE_TYPE" == "$PRERELEASE" ]; then
+      NEW_PRERELEASE="${PRERELEASE}.$((CURRENT_PRERELEASE_NUM + 1))"
+    elif [ "$CURRENT_PRERELEASE_TYPE" == "alpha" ] && [ "$PRERELEASE" == "beta" ]; then
+      NEW_PRERELEASE="${PRERELEASE}.1"
+    fi
+  fi
+fi
+
+if [ -n "$NEW_PRERELEASE" ]; then
+  NEW_TAG="v${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}-${NEW_PRERELEASE}"
+else
+  NEW_TAG="v${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"
+fi
+
+echo "$NEW_TAG"

--- a/scripts/bump_version_test.go
+++ b/scripts/bump_version_test.go
@@ -1,0 +1,173 @@
+package scripts
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalcNewVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		initialTag string
+		args       []string
+		expected   string
+		wantErr    bool
+	}{
+		{
+			name:       "initial patch bump",
+			initialTag: "",
+			args:       []string{"patch"},
+			expected:   "v0.0.1",
+			wantErr:    false,
+		},
+		{
+			name:       "initial minor bump",
+			initialTag: "",
+			args:       []string{"minor"},
+			expected:   "v0.1.0",
+			wantErr:    false,
+		},
+		{
+			name:       "initial major bump",
+			initialTag: "",
+			args:       []string{"major"},
+			expected:   "v1.0.0",
+			wantErr:    false,
+		},
+		{
+			name:       "patch bump normal",
+			initialTag: "v1.2.3",
+			args:       []string{"patch"},
+			expected:   "v1.2.4",
+			wantErr:    false,
+		},
+		{
+			name:       "minor bump normal",
+			initialTag: "v1.2.3",
+			args:       []string{"minor"},
+			expected:   "v1.3.0",
+			wantErr:    false,
+		},
+		{
+			name:       "major bump normal",
+			initialTag: "v1.2.3",
+			args:       []string{"major"},
+			expected:   "v2.0.0",
+			wantErr:    false,
+		},
+		{
+			name:       "patch bump with alpha when base is normal",
+			initialTag: "v1.2.3",
+			args:       []string{"patch", "alpha"},
+			expected:   "v1.2.4-alpha.1",
+			wantErr:    false,
+		},
+		{
+			name:       "patch bump with alpha when base is already alpha",
+			initialTag: "v1.2.3-alpha.1",
+			args:       []string{"patch", "alpha"},
+			expected:   "v1.2.3-alpha.2",
+			wantErr:    false,
+		},
+		{
+			name:       "patch bump with beta when base is already beta",
+			initialTag: "v1.2.3-beta.2",
+			args:       []string{"patch", "beta"},
+			expected:   "v1.2.3-beta.3",
+			wantErr:    false,
+		},
+		{
+			name:       "patch bump with alpha when switching from beta",
+			initialTag: "v1.2.3-beta.2",
+			args:       []string{"patch", "alpha"},
+			expected:   "Error: Switching from beta to alpha in a patch bump is not allowed without a numeric bump.",
+			wantErr:    true,
+		},
+		{
+			name:       "patch bump with beta when switching from alpha",
+			initialTag: "v1.2.3-alpha.2",
+			args:       []string{"patch", "beta"},
+			expected:   "v1.2.3-beta.1",
+			wantErr:    false,
+		},
+		{
+			name:       "no arguments provided",
+			initialTag: "v1.2.3",
+			args:       []string{},
+			expected:   "Usage: ",
+			wantErr:    true,
+		},
+		{
+			name:       "invalid release type",
+			initialTag: "v1.2.3",
+			args:       []string{"invalid"},
+			expected:   "Error: release type must be one of:",
+			wantErr:    true,
+		},
+		{
+			name:       "invalid prerelease value",
+			initialTag: "v1.2.3",
+			args:       []string{"patch", "rc"},
+			expected:   "Error: prerelease, if provided, must be alpha or beta",
+			wantErr:    true,
+		},
+		{
+			name:       "invalid latest tag format",
+			initialTag: "invalid",
+			args:       []string{"patch"},
+			expected:   "Error: Latest tag 'invalid' is not in a valid semantic version format.",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tempDir, err := os.MkdirTemp("", "testrepo-*")
+			require.NoError(t, err, "failed to create temp dir")
+			t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+			cmd := exec.Command("git", "init")
+			cmd.Dir = tempDir
+			out, err := cmd.CombinedOutput()
+			require.NoError(t, err, "git init failed: %s", string(out))
+
+			if tt.initialTag != "" {
+				cmd = exec.Command("git", "commit", "--allow-empty", "-m", "init")
+				cmd.Dir = tempDir
+				out, err = cmd.CombinedOutput()
+				require.NoError(t, err, "git commit failed: %s", string(out))
+
+				cmd = exec.Command("git", "tag", tt.initialTag)
+				cmd.Dir = tempDir
+				out, err = cmd.CombinedOutput()
+				require.NoError(t, err, "git tag failed: %s", string(out))
+			}
+
+			scriptPath, err := filepath.Abs(filepath.Join("bump_version.sh"))
+			require.NoError(t, err, "failed to get absolute path for the script")
+
+			cmd = exec.Command(scriptPath, tt.args...)
+			cmd.Dir = tempDir
+			outputBytes, err := cmd.CombinedOutput()
+
+			if tt.wantErr {
+				require.Error(t, err, "script unexpectedly succeeded")
+				assert.Contains(t, string(outputBytes), tt.expected, "expected error message %s, got %s", tt.expected, string(outputBytes))
+			} else {
+				require.NoError(t, err, "script failed: %v", err)
+				newVersion := strings.TrimSpace(string(outputBytes))
+				assert.Contains(t, tt.expected, newVersion, "expected version %s, got %s", tt.expected, newVersion)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### TL;DR
Added automated versioning and release workflows with support for semantic versioning and pre-releases.

### What changed?
- Added version command to display current version of gcat
- Created new GitHub Actions workflows for version bumping and releases
- Implemented semantic versioning with support for major, minor, and patch releases
- Added pre-release support for alpha and beta versions
- Integrated GoReleaser for automated binary distribution
- Added version bump script with comprehensive test coverage

### How to test?
1. Run `gcat version` to verify version command
2. Create a PR with labels `major`, `minor`, or `patch` to trigger version bump
3. Add `alpha` or `beta` labels for pre-release versions
4. Merge PR to trigger version bump and release
5. Manually trigger version bump workflow with desired parameters
6. Verify released artifacts in GitHub releases

### Why make this change?
To establish a standardized versioning system and automate the release process, making it easier to track changes and distribute new versions of gcat to users. This also ensures consistent version numbering across releases and provides a clear upgrade path for users.