### PR TITLE
Add manual trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*" # trigger only when a semantic version tag is pushed
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
### TL;DR
Added manual trigger capability to the release workflow

### What changed?
Added `workflow_dispatch` event trigger to the release GitHub Action workflow

### How to test?
1. Navigate to the Actions tab in GitHub
2. Select the "Release" workflow
3. Click "Run workflow" dropdown
4. Verify the workflow can be triggered manually

### Why make this change?
Enables manual execution of the release workflow when needed, instead of relying solely on tag-based triggers. This provides more flexibility in managing releases, especially in scenarios where immediate deployment is required without creating a new tag.