### PR TITLE
Update semantic version tag pattern in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*.*.*" # trigger only when a semantic version tag is pushed
+      - "v[0-9]+.[0-9]+.[0-9]+*" # trigger only when a semantic version tag is pushed
 
 jobs:
   release:


### PR DESCRIPTION
### TL;DR
Updated the tag pattern matching in the release workflow to use a more precise semantic versioning regex.

### What changed?
Modified the tag trigger pattern from `v*.*.*` to `v[0-9]+.[0-9]+.[0-9]+*` in the release workflow configuration.

### How to test?
1. Create and push a tag following semantic versioning (e.g., `v1.2.3`)
2. Verify the release workflow triggers
3. Create and push a malformed tag (e.g., `va.b.c`)
4. Verify the release workflow does not trigger

### Why make this change?
The previous pattern was too permissive and could potentially trigger on malformed version tags. The new regex pattern ensures the workflow only runs for properly formatted semantic version tags, preventing accidental releases.