### PR TITLE
Update version workflow authentication and tag patterns

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,9 @@ name: Release
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+*" # trigger only when a semantic version tag is pushed
+      - "v*.*.*" # Matches standard versions
+      - "v*.*.*-*" # Matches prerelease versions
+  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,7 +1,6 @@
 name: Version Bump
 
 permissions:
-  contents: write
   pull-requests: write
   issues: write
 
@@ -30,6 +29,7 @@ on:
 
 jobs:
   calculate-version:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     outputs:
       new_version: ${{ steps.calc.outputs.new_version }}
@@ -170,5 +170,8 @@ jobs:
           NEW_VERSION: ${{ needs.calculate-version.outputs.new_version }}
         run: |
           echo "Tagging new version: $NEW_VERSION"
+          git config user.name "gcat CI"
+          git config user.email "ci@timsexperiments.foo"
           git tag "$NEW_VERSION"
+          git remote set-url origin https://x-access-token:${{ secrets.RELEASE_TOKEN }}@github.com/${{ github.repository }}
           git push origin "$NEW_VERSION"


### PR DESCRIPTION
### TL;DR
Enhanced version control automation and release workflow configuration

### What changed?
- Updated tag pattern matching to support both standard and prerelease versions
- Added manual trigger capability through `workflow_dispatch`
- Excluded Dependabot from version calculation process
- Added git configuration for CI user identity
- Implemented secure token-based remote URL for pushing tags

### How to test?
1. Create a new version tag following either format:
   - Standard: `v1.2.3`
   - Prerelease: `v1.2.3-beta`
2. Push the tag to trigger the release workflow
3. Verify the workflow runs successfully
4. Test manual workflow trigger through GitHub Actions UI

### Why make this change?
To improve the reliability and security of the automated release process while adding support for prerelease versions and manual triggers. The changes also ensure proper authentication and identification of CI-driven commits.