### PR TITLE
Downgrade checkout action and update git auth in version workflow

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -38,7 +38,7 @@ jobs:
       prerelease: ${{ steps.determine.outputs.prerelease }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -158,7 +158,7 @@ jobs:
     if: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.state == 'closed')) && needs.calculate-version.outputs.release_type != '' }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Set up Git
         run: |
@@ -168,10 +168,11 @@ jobs:
       - name: Create Version Tag
         env:
           NEW_VERSION: ${{ needs.calculate-version.outputs.new_version }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           echo "Tagging new version: $NEW_VERSION"
           git config user.name "gcat CI"
           git config user.email "ci@timsexperiments.foo"
           git tag "$NEW_VERSION"
-          git remote set-url origin https://x-access-token:${{ secrets.RELEASE_TOKEN }}@github.com/${{ github.repository }}
+          gh auth setup-git
           git push origin "$NEW_VERSION"


### PR DESCRIPTION
### TL;DR
Downgraded GitHub Actions checkout to v3 and simplified git authentication using the GitHub CLI.

### What changed?
- Downgraded `actions/checkout` from v4 to v3 in version workflow
- Replaced manual git remote URL configuration with `gh auth setup-git`
- Added `GH_TOKEN` environment variable for GitHub CLI authentication

### How to test?
1. Trigger the version workflow manually or via PR merge
2. Verify that version tagging completes successfully
3. Confirm the tag is pushed to the repository

### Why make this change?
The checkout action downgrade addresses potential compatibility issues, while using the GitHub CLI for authentication provides a more secure and maintainable approach to git operations in CI/CD workflows.