### PR TITLE
Update version workflow to use GitHub API for tag creation

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -166,13 +166,21 @@ jobs:
           git config user.email "ci@timsexperiments.foo"
 
       - name: Create Version Tag
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.RELEASE_TOKEN }}
+          script: |
+            const { NEW_VERSION } = process.env;
+            console.log(`Creating tag: ${NEW_VERSION}`);
+
+            // Create the tag reference
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${NEW_VERSION}`,
+              sha: context.sha
+            });
+
+            console.log(`Successfully created tag ${NEW_VERSION}`);
         env:
           NEW_VERSION: ${{ needs.calculate-version.outputs.new_version }}
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        run: |
-          echo "Tagging new version: $NEW_VERSION"
-          git config user.name "gcat CI"
-          git config user.email "ci@timsexperiments.foo"
-          git tag "$NEW_VERSION"
-          gh auth setup-git
-          git push origin "$NEW_VERSION"


### PR DESCRIPTION
### TL;DR
Updated version workflow to use GitHub Actions Script for tag creation instead of git CLI commands.

### What changed?
Replaced manual git tag creation and push commands with the GitHub Actions Script API. The script now creates tags using the REST API, which provides better error handling and integration with GitHub's platform.

### How to test?
1. Create a new PR that would trigger a version bump
2. Verify that the version workflow executes successfully
3. Confirm that a new tag is created in the repository with the correct version number
4. Verify that the tag is properly linked to the correct commit SHA

### Why make this change?
Using the GitHub Actions Script API provides better reliability and security compared to git CLI commands. It eliminates potential issues with git authentication and provides native integration with GitHub's infrastructure.