### PR TITLE
Remove --rm-dist flag from goreleaser command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          args: release --rm-dist
+          args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### TL;DR
Removed `--rm-dist` flag from GoReleaser action command

### What changed?
Modified the GoReleaser action command in the release workflow by removing the `--rm-dist` flag, simplifying the release process to use default cleanup behavior

### How to test?
1. Create a new release tag
2. Verify the GitHub Action workflow executes successfully
3. Confirm release artifacts are properly generated and published

### Why make this change?
The `--rm-dist` flag is no longer necessary as GoReleaser handles cleanup automatically. Removing this flag aligns with current best practices and simplifies the release configuration.