### PR TITLE
Remove format specification from goreleaser archives

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,8 +12,7 @@ builds:
     ldflags: "-s -w -X main.version={{ .Version }}"
 
 archives:
-  - format: tar.gz
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - README.md
       - LICENSE.md


### PR DESCRIPTION
### TL;DR
Removed explicit format specification from goreleaser archives configuration

### What changed?
Removed the `format: tar.gz` line from the `.goreleaser.yml` configuration file, allowing goreleaser to use its default archive format settings.

### How to test?
1. Run `goreleaser build --snapshot --clean`
2. Verify that archives are still created correctly
3. Ensure the generated artifacts maintain the specified name template pattern

### Why make this change?
The `tar.gz` format is already the default archive format for goreleaser. Removing the explicit format specification reduces configuration redundancy while maintaining the same functionality.