### PR TITLE
Update release configuration and add installation docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,13 +11,10 @@ builds:
       - windows
     goarch:
       - amd64
-    ldflags: "-s -w -X main.version={{ .Version }}"
+    ldflags: "-s -w -X main.version=v{{ .Version }}"
 
 archives:
-  - format_overrides:
-      - goos: windows
-        format: zip
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - README.md
       - LICENSE.md

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ This tool is perfect for creating a single, LLM–friendly string containing mul
 
 ## Installation
 
+### Option 1: Using Go Install (recommended)
+
+```bash
+go install github.com/timsexperiments/gcat/cmd/gcat@latest
+```
+
+### Option 2: Pre-built binaries
+
+Download the pre-built binary for your platform from the [releases page](https://github.com/timsexperiments/gcat/releases).
+
+### Option 3: Build from source
+
 1. **Clone the Repository:**
 
    ```bash


### PR DESCRIPTION
### TL;DR
Improves release workflow and updates installation documentation

### What changed?
- Added `fetch-depth: 0` to checkout action in release workflow
- Modified version string format in goreleaser config to include 'v' prefix
- Removed zip format override for Windows builds
- Added new installation methods to README.md including go install and pre-built binaries

### How to test?
1. Run `go install github.com/timsexperiments/gcat/cmd/gcat@latest`
2. Verify the installation works
3. Create a new release and ensure binaries are generated correctly
4. Check that version string includes 'v' prefix

### Why make this change?
- Ensures proper version history for releases
- Standardizes version formatting across the project
- Simplifies the installation process for users by providing multiple installation options
- Makes the project more accessible to users who prefer pre-built binaries