### PR TITLE
update goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
       - windows
     goarch:
       - amd64
+      - arm64
     ldflags: "-s -w -X main.version=v{{ .Version }}"
 
 archives:


### PR DESCRIPTION
### TL;DR
Added ARM64 architecture support and simplified installation instructions in README

### What changed?
- Added ARM64 architecture to goreleaser build configuration
- Removed "Option 1: Using Go Install" and "Option 2: Pre-built binaries" sections from README
- Simplified installation section to focus on building from source

### How to test?
1. Build the project on an ARM64 device
2. Verify the binary executes correctly
3. Check that the README displays correctly on GitHub

### Why make this change?
To expand platform support by including ARM64 architecture, making the tool accessible to users with ARM-based devices like M1/M2 Macs. The README simplification reduces maintenance overhead and potential confusion by focusing on a single, reliable installation method.