### PR TITLE
remove commnt

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -173,7 +173,6 @@ jobs:
             const { NEW_VERSION } = process.env;
             console.log(`Creating tag: ${NEW_VERSION}`);
 
-            // Create the tag reference
             await github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
### TL;DR
Removed unnecessary comment in version workflow

### What changed?
Removed a redundant code comment `// Create the tag reference` from the version.yml GitHub Actions workflow file, as the code is self-documenting through its function name `createRef`.

### How to test?
1. Create a new version/release
2. Verify that the tag creation still works as expected
3. Confirm the workflow runs successfully

### Why make this change?
The removed comment was redundant and didn't provide additional context beyond what the function name already clearly indicates. This change helps maintain cleaner, more maintainable code by reducing unnecessary comments.