### PR TITLE
add v prefix to archive names

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Determine Release Parameters
         id: determine
@@ -78,7 +79,7 @@ jobs:
         id: calc
         if: ${{ steps.determine.outputs.release_type != '' }}
         run: |
-          OLD_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          OLD_VERSION=$(git tag -l 'v*' | sort -V | tail -n 1 || echo "")
           echo "old_version=$OLD_VERSION" >> $GITHUB_OUTPUT
 
           NEW_VERSION=$(./scripts/bump_version.sh "${{ steps.determine.outputs.release_type }}" "${{ steps.determine.outputs.prerelease }}" || echo "")

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
     ldflags: "-s -w -X main.version=v{{ .Version }}"
 
 archives:
-  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - README.md
       - LICENSE.md

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -30,7 +30,8 @@ if [ -n "$PRERELEASE" ]; then
   fi
 fi
 
-LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+LATEST_TAG=$(git tag -l 'v*' | sort -V | tail -n 1)
+LATEST_TAG=${LATEST_TAG:-v0.0.0}
 
 VERSION_NO_V=${LATEST_TAG#v}
 if [[ $VERSION_NO_V =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-([a-z]+)\.([0-9]+))?$ ]]; then

--- a/scripts/bump_version_test.go
+++ b/scripts/bump_version_test.go
@@ -1,6 +1,7 @@
 package scripts
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -121,9 +122,9 @@ func TestCalcNewVersion(t *testing.T) {
 		},
 		{
 			name:       "invalid latest tag format",
-			initialTag: "invalid",
+			initialTag: "vinvalid",
 			args:       []string{"patch"},
-			expected:   "Error: Latest tag 'invalid' is not in a valid semantic version format.",
+			expected:   "Error: Latest tag 'vinvalid' is not in a valid semantic version format.",
 			wantErr:    true,
 		},
 	}
@@ -159,6 +160,7 @@ func TestCalcNewVersion(t *testing.T) {
 			cmd = exec.Command(scriptPath, tt.args...)
 			cmd.Dir = tempDir
 			outputBytes, err := cmd.CombinedOutput()
+			fmt.Println(string(outputBytes))
 
 			if tt.wantErr {
 				require.Error(t, err, "script unexpectedly succeeded")


### PR DESCRIPTION
### TL;DR
Added 'v' prefix to version number in release archive filenames

### What changed?
Modified the `name_template` in `.goreleaser.yml` to include a 'v' prefix before the version number in the generated archive filenames. Archive names will now follow the pattern: `projectname_v1.0.0_os_arch` instead of `projectname_1.0.0_os_arch`

### How to test?
1. Run `goreleaser build --snapshot`
2. Check the generated archives in the `dist` directory
3. Verify that archive filenames include the 'v' prefix before the version number

### Why make this change?
Ensures consistency between version tags and release archive filenames, making it easier to identify release versions in downloaded artifacts. This aligns with semantic versioning best practices where version numbers commonly include the 'v' prefix.